### PR TITLE
Fix numpy dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
   <license>BSD</license>
 
-  <depend>python-numpy</depend>
+  <depend>python3-numpy</depend>
   <depend>python-transforms3d-pip</depend>
 
   <test_depend>ament_flake8</test_depend>

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ package_name = 'tf_transformations'
 
 setup(
     name=package_name,
-    version='1.0.0',
+    version='1.0.2',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages',


### PR DESCRIPTION
```bash
~/ros_ws# rosdep install -i --from-path src --rosdistro humble --ignore-src
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
tf_transformations: No definition of [python-numpy] for OS version [jammy]
```