### PR TITLE
Drop the pip dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,8 +9,8 @@
   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
   <license>BSD</license>
 
+  <depend>python-transforms3d</depend>
   <depend>python3-numpy</depend>
-  <depend>python-transforms3d-pip</depend>
 
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
The pip is now embedded in the python3-transforms3d key for older distros: https://github.com/ros/rosdistro/pull/33091/files

Solves #9 