### PR TITLE
Precommit configuration and spelling fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  hooks:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+  - id: check-merge-conflict
+  - id: mixed-line-ending
+  - id: check-executables-have-shebangs
+  - id: check-shebang-scripts-are-executable
+  - id: detect-private-key
+  - id: destroyed-symlinks
+  - id: check-symlinks
+  - id: check-case-conflict
+  - id: check-ast
+  - id: double-quote-string-fixer
+  - id: requirements-txt-fixer
+  - id: check-xml
+  rev: v4.5.0
+- repo: https://github.com/codespell-project/codespell
+  hooks:
+  - id: codespell
+    args:
+    - --write-changes
+  rev: v2.2.6
+- repo: https://github.com/hhatto/autopep8
+  hooks:
+  - id: autopep8
+  rev: v2.1.0
+- repo: https://github.com/PyCQA/flake8
+  hooks:
+  - id: flake8
+  rev: 7.0.0
+ci:
+  autoupdate_schedule: quarterly

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,8 @@
 [develop]
 script_dir=$base/lib/tf_transformations
+
 [install]
 install_scripts=$base/lib/tf_transformations
+
+[flake8]
+max_line_length=120

--- a/test/test_transformations.py
+++ b/test/test_transformations.py
@@ -233,21 +233,21 @@ def test_projection_from_matrix():
 
 
 def test_clip_matrix():
-    frustrum = numpy.random.rand(6)
-    frustrum[1] += frustrum[0]
-    frustrum[3] += frustrum[2]
-    frustrum[5] += frustrum[4]
-    M = clip_matrix(*frustrum, perspective=False)
+    frustum = numpy.random.rand(6)
+    frustum[1] += frustum[0]
+    frustum[3] += frustum[2]
+    frustum[5] += frustum[4]
+    M = clip_matrix(*frustum, perspective=False)
     assert numpy.allclose(
-        numpy.dot(M, [frustrum[0], frustrum[2], frustrum[4], 1.0]),
+        numpy.dot(M, [frustum[0], frustum[2], frustum[4], 1.0]),
         [-1., -1., -1.,  1.])
     assert numpy.allclose(
-        numpy.dot(M, [frustrum[1], frustrum[3], frustrum[5], 1.0]),
+        numpy.dot(M, [frustum[1], frustum[3], frustum[5], 1.0]),
         [1.,  1.,  1.,  1.])
-    M = clip_matrix(*frustrum, perspective=True)
-    v = numpy.dot(M, [frustrum[0], frustrum[2], frustrum[4], 1.0])
+    M = clip_matrix(*frustum, perspective=True)
+    v = numpy.dot(M, [frustum[0], frustum[2], frustum[4], 1.0])
     assert numpy.allclose(v / v[3], [-1., -1., -1.,  1.])
-    v = numpy.dot(M, [frustrum[1], frustrum[3], frustrum[4], 1.0])
+    v = numpy.dot(M, [frustum[1], frustum[3], frustum[4], 1.0])
     assert numpy.allclose(v / v[3], [1.,  1., -1.,  1.])
 
 

--- a/tf_transformations/__init__.py
+++ b/tf_transformations/__init__.py
@@ -373,35 +373,35 @@ def projection_from_matrix(matrix, pseudo=False):
 
 def clip_matrix(left, right, bottom, top, near, far, perspective=False):
     """
-    Return matrix to obtain normalized device coordinates from frustrum.
+    Return matrix to obtain normalized device coordinates from frustum.
 
-    The frustrum bounds are axis-aligned along x (left, right),
+    The frustum bounds are axis-aligned along x (left, right),
     y (bottom, top) and z (near, far).
 
     Normalized device coordinates are in range [-1, 1] if coordinates are
-    inside the frustrum.
+    inside the frustum.
 
-    If perspective is True the frustrum is a truncated pyramid with the
+    If perspective is True the frustum is a truncated pyramid with the
     perspective point at origin and direction along z axis, otherwise an
     orthographic canonical view volume (a box).
 
     Homogeneous coordinates transformed by the perspective clip matrix
-    need to be dehomogenized (devided by w coordinate).
+    need to be dehomogenized (divided by w coordinate).
 
-    >>> frustrum = numpy.random.rand(6)
-    >>> frustrum[1] += frustrum[0]
-    >>> frustrum[3] += frustrum[2]
-    >>> frustrum[5] += frustrum[4]
-    >>> M = clip_matrix(*frustrum, perspective=False)
-    >>> numpy.dot(M, [frustrum[0], frustrum[2], frustrum[4], 1.0])
+    >>> frustum = numpy.random.rand(6)
+    >>> frustum[1] += frustum[0]
+    >>> frustum[3] += frustum[2]
+    >>> frustum[5] += frustum[4]
+    >>> M = clip_matrix(*frustum, perspective=False)
+    >>> numpy.dot(M, [frustum[0], frustum[2], frustum[4], 1.0])
     array([-1., -1., -1.,  1.])
-    >>> numpy.dot(M, [frustrum[1], frustrum[3], frustrum[5], 1.0])
+    >>> numpy.dot(M, [frustum[1], frustum[3], frustum[5], 1.0])
     array([ 1.,  1.,  1.,  1.])
-    >>> M = clip_matrix(*frustrum, perspective=True)
-    >>> v = numpy.dot(M, [frustrum[0], frustrum[2], frustrum[4], 1.0])
+    >>> M = clip_matrix(*frustum, perspective=True)
+    >>> v = numpy.dot(M, [frustum[0], frustum[2], frustum[4], 1.0])
     >>> v / v[3]
     array([-1., -1., -1.,  1.])
-    >>> v = numpy.dot(M, [frustrum[1], frustrum[3], frustrum[4], 1.0])
+    >>> v = numpy.dot(M, [frustum[1], frustum[3], frustum[4], 1.0])
     >>> v / v[3]
     array([ 1.,  1., -1.,  1.])
 
@@ -410,7 +410,7 @@ def clip_matrix(left, right, bottom, top, near, far, perspective=False):
         raise ValueError('invalid frustrum')
     if perspective:
         if near <= _EPS:
-            raise ValueError('invalid frustrum: near <= 0')
+            raise ValueError('invalid frustum: near <= 0')
         t = 2.0 * near
         M = ((-t/(right-left), 0.0, (right+left)/(right-left), 0.0),
              (0.0, -t/(top-bottom), (top+bottom)/(top-bottom), 0.0),
@@ -782,7 +782,7 @@ def quaternion_about_axis(angle, axis):
 
 def quaternion_matrix(quaternion):
     """
-    Return 4x4 homogenous rotation matrix from quaternion.
+    Return 4x4 homogeneous rotation matrix from quaternion.
 
     >>> R = quaternion_matrix([0.06146124, 0, 0, 0.99810947])
     >>> numpy.allclose(R, rotation_matrix(0.123, (1, 0, 0)))


### PR DESCRIPTION
[![Screenshot 2024-06-18 at 11-23-05 Frustum -- from Wolfram MathWorld](https://github.com/DLu/tf_transformations/assets/1016143/978523a3-034b-427c-92ff-82e3b0c7914b)](https://mathworld.wolfram.com/Frustum.html)